### PR TITLE
Android is Unix

### DIFF
--- a/lib/Perl/OSType.pm
+++ b/lib/Perl/OSType.pm
@@ -50,6 +50,7 @@ my %OSTYPES = qw(
   gnukfreebsd Unix
   nto         Unix
   qnx         Unix
+  android     Unix
 
   dos         Windows
   MSWin32     Windows


### PR DESCRIPTION
On Android the tests fail at:

not ok 9 - os_type(): without arguments

Could you add "android" to the %OSTYPES please?
