### PR TITLE
Add support for msys2

### DIFF
--- a/lib/Perl/OSType.pm
+++ b/lib/Perl/OSType.pm
@@ -47,6 +47,7 @@ my %OSTYPES = qw(
   solaris     Unix
   sunos       Unix
   cygwin      Unix
+  msys        Unix
   os2         Unix
   interix     Unix
   gnu         Unix


### PR DESCRIPTION
The perl that comes with MSYS2 reports $^O as 'msys'.  The Perl port is substantially similar to cygwin (it even supports at least some of the Cygwin:: API), so if cygwin is Unix, I think MSYS2 should also be.
